### PR TITLE
Fix compareFilesMD5 null handling

### DIFF
--- a/api/src/main/java/telegram/files/MessyUtils.java
+++ b/api/src/main/java/telegram/files/MessyUtils.java
@@ -58,8 +58,18 @@ public class MessyUtils {
             }
         });
 
-        String md5File1 = md5Task1.join();
-        String md5File2 = md5Task2.join();
+        String md5File1 = null;
+        String md5File2 = null;
+        try {
+            md5File1 = md5Task1.join();
+            md5File2 = md5Task2.join();
+        } catch (Exception ignore) {
+            return false;
+        }
+
+        if (md5File1 == null || md5File2 == null) {
+            return false;
+        }
 
         return md5File1.equals(md5File2);
     }

--- a/api/src/test/java/telegram/files/MessyUtilsTest.java
+++ b/api/src/test/java/telegram/files/MessyUtilsTest.java
@@ -72,6 +72,13 @@ class MessyUtilsTest {
         assertFalse(MessyUtils.compareFilesMD5(smallFile, largeFile), "MD5 hashes for different files should not match!");
     }
 
+    @Test
+    void testCompareFilesMD5ForMissingFile() {
+        File missingFile = new File("missing.txt");
+        assertFalse(MessyUtils.compareFilesMD5(smallFile, missingFile),
+                "MD5 comparison should return false if one of the files is missing!");
+    }
+
     private String calculateExpectedMD5(File file) throws Exception {
         MessageDigest md = MessageDigest.getInstance("MD5");
         byte[] fileBytes = Files.readAllBytes(file.toPath());


### PR DESCRIPTION
## Summary
- handle missing files in `MessyUtils.compareFilesMD5`
- test MD5 comparison with a missing file

## Testing
- `./api/gradlew -p api test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_6841bc979d8c8332a2b58be04fef259f