### PR TITLE
fix: selection of files to add to transfer queue

### DIFF
--- a/api/src/main/java/telegram/files/TransferVerticle.java
+++ b/api/src/main/java/telegram/files/TransferVerticle.java
@@ -137,7 +137,7 @@ public class TransferVerticle extends AbstractVerticle {
                 continue;
             }
             Tuple3<List<FileRecord>, Long, Long> filesTuple = Future.await(DataVerticle.fileRepository.getFiles(automation.chatId,
-                    Map.of("status", FileRecord.DownloadStatus.completed.name(),
+                    Map.of("downloadStatus", FileRecord.DownloadStatus.completed.name(),
                             "transferStatus", FileRecord.TransferStatus.idle.name()
                     )
             ));


### PR DESCRIPTION
There is no "status" filter in the fileRepository implementation. I assume this was overlooked during the Transfer feature implementation.

<br/>
<div align="center">
  <img src="../web/public/favicon.svg" height="80" alt="" />
  <h3>Telegram Files</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors, and keeps the code clean and readable
- [x] Pull request targets ``dev`` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/) and [git emoji](https://gitmoji.dev/)
