### PR TITLE
✨ feat: eager thumbnail previews (crisp previews before download)

### DIFF
--- a/api/src/main/java/telegram/files/TdApiHelp.java
+++ b/api/src/main/java/telegram/files/TdApiHelp.java
@@ -363,6 +363,37 @@ public class TdApiHelp {
                     "height", photo.height,
                     "type", photo.type);
         }
+
+        @Override
+        public TdApi.Thumbnail getThumbnail() {
+            TdApi.PhotoSize[] sizes = content.photo.sizes;
+            if (sizes == null || sizes.length == 0) {
+                return null;
+            }
+            TdApi.PhotoSize fullSize = sizes[sizes.length - 1];
+            // Prefer the ~320px "m" box: crisp enough for a preview yet small (~10-30KB).
+            TdApi.PhotoSize preview = null;
+            for (TdApi.PhotoSize size : sizes) {
+                if ("m".equals(size.type)) {
+                    preview = size;
+                    break;
+                }
+            }
+            // Otherwise fall back to the smallest available size.
+            if (preview == null) {
+                preview = sizes[0];
+                for (TdApi.PhotoSize size : sizes) {
+                    if (Math.max(size.width, size.height) < Math.max(preview.width, preview.height)) {
+                        preview = size;
+                    }
+                }
+            }
+            // If the only available size is the full-resolution image, there's no lighter preview.
+            if (preview.photo.remote.uniqueId.equals(fullSize.photo.remote.uniqueId)) {
+                return null;
+            }
+            return new TdApi.Thumbnail(new TdApi.ThumbnailFormatJpeg(), preview.width, preview.height, preview.photo);
+        }
     }
 
     public static class VideoHandler extends FileHandler<TdApi.MessageVideo> {

--- a/api/src/main/java/telegram/files/TelegramConverter.java
+++ b/api/src/main/java/telegram/files/TelegramConverter.java
@@ -53,17 +53,32 @@ public class TelegramConverter {
     }
 
     public static Future<JsonArray> convertFiles(long telegramId, TdApi.Message[] messages) {
-        return DataVerticle.fileRepository.getFilesByUniqueId(TdApiHelp.getFileUniqueIds(Arrays.asList(messages)))
-                .compose(fileRecords ->
-                        FileRecordRetriever.getThumbnails(fileRecords.values())
-                                .map(thumbnails -> Tuple.tuple(fileRecords, thumbnails))
-                )
+        List<TdApi.Message> messageList = Arrays.asList(messages);
+        return DataVerticle.fileRepository.getFilesByUniqueId(TdApiHelp.getFileUniqueIds(messageList))
+                .compose(fileRecords -> {
+                    // Collect thumbnail uniqueIds from both the stored records and the live messages,
+                    // so previews can use the lightweight thumbnail even for files not tracked in the DB.
+                    Set<String> thumbnailUniqueIds = new HashSet<>();
+                    fileRecords.values().forEach(fileRecord -> {
+                        if (StrUtil.isNotBlank(fileRecord.thumbnailUniqueId())) {
+                            thumbnailUniqueIds.add(fileRecord.thumbnailUniqueId());
+                        }
+                    });
+                    messageList.forEach(message -> TdApiHelp.getFileHandler(message).ifPresent(handler -> {
+                        String thumbnailUniqueId = handler.getThumbnailFileUniqueId();
+                        if (StrUtil.isNotBlank(thumbnailUniqueId)) {
+                            thumbnailUniqueIds.add(thumbnailUniqueId);
+                        }
+                    }));
+                    return DataVerticle.fileRepository.getFilesByUniqueId(new ArrayList<>(thumbnailUniqueIds))
+                            .map(thumbnails -> Tuple.tuple(fileRecords, thumbnails));
+                })
                 .compose(t -> DataVerticle.settingRepository.<Boolean>getByKey(SettingKey.uniqueOnly).map(t::concat))
                 .map(t -> {
                     Map<String, FileRecord> fileRecords = t.v1;
                     Map<String, FileRecord> thumbnails = t.v2;
-                    List<TdApi.Message> filterMessages = t.v3 ? TdApiHelp.filterUniqueMessages(Arrays.asList(messages))
-                            : Arrays.asList(messages);
+                    List<TdApi.Message> filterMessages = t.v3 ? TdApiHelp.filterUniqueMessages(messageList)
+                            : messageList;
 
                     List<JsonObject> fileObjects = filterMessages.stream()
                             .filter(message -> TdApiHelp.FILE_CONTENT_CONSTRUCTORS.contains(message.content.getConstructor()))
@@ -71,9 +86,12 @@ public class TelegramConverter {
                                 //TODO Processing of the same file under different accounts
 
                                 FileRecord fileRecord = fileRecords.get(TdApiHelp.getFileUniqueId(message));
+                                String thumbnailUniqueId = fileRecord != null && StrUtil.isNotBlank(fileRecord.thumbnailUniqueId())
+                                        ? fileRecord.thumbnailUniqueId()
+                                        : TdApiHelp.getFileHandler(message).map(handler -> handler.getThumbnailFileUniqueId()).orElse(null);
                                 return withSource(telegramId,
                                         fileRecord,
-                                        fileRecord == null || StrUtil.isBlank(fileRecord.thumbnailUniqueId()) ? null : thumbnails.get(fileRecord.thumbnailUniqueId()),
+                                        StrUtil.isBlank(thumbnailUniqueId) ? null : thumbnails.get(thumbnailUniqueId),
                                         message);
                             })
                             .filter(Objects::nonNull)

--- a/api/src/main/java/telegram/files/TelegramVerticle.java
+++ b/api/src/main/java/telegram/files/TelegramVerticle.java
@@ -24,11 +24,13 @@ import org.jooq.lambda.tuple.Tuple2;
 import telegram.files.repository.*;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
 public class TelegramVerticle extends AbstractVerticle {
@@ -380,21 +382,48 @@ public class TelegramVerticle extends AbstractVerticle {
      * while browsing, without having to download the full media. Fire-and-forget: already
      * downloaded thumbnails are skipped by {@link #downloadThumbnail}.
      */
+    private static final int MAX_PRELOAD_THUMBNAILS = 30;
+
+    private static final int PRELOAD_THUMBNAIL_CONCURRENCY = 3;
+
     private void preloadThumbnails(TdApi.FoundChatMessages foundChatMessages) {
         if (foundChatMessages == null || foundChatMessages.messages == null || telegramRecord == null) {
             return;
         }
+        // Collect at most MAX_PRELOAD_THUMBNAILS thumbnail records for this page, then download them
+        // with bounded concurrency, so opening large pages or fast scrolling can't burst TDLib, the
+        // DB and websocket with one download per message.
+        List<FileRecord> thumbnails = new ArrayList<>();
         for (TdApi.Message message : foundChatMessages.messages) {
-            TdApiHelp.getFileHandler(message).ifPresent(fileHandler -> {
-                FileRecord thumbnailRecord = fileHandler.convertThumbnailRecord(telegramRecord.id());
-                if (thumbnailRecord == null) {
-                    return;
-                }
-                downloadThumbnail(message.chatId, message.id, thumbnailRecord)
-                        .onFailure(err -> log.debug("[%s] Preload thumbnail failed for message %d: %s"
-                                .formatted(getRootId(), message.id, err.getMessage())));
-            });
+            if (thumbnails.size() >= MAX_PRELOAD_THUMBNAILS) {
+                break;
+            }
+            FileRecord thumbnailRecord = TdApiHelp.getFileHandler(message)
+                    .map(fileHandler -> fileHandler.convertThumbnailRecord(telegramRecord.id()))
+                    .orElse(null);
+            if (thumbnailRecord != null) {
+                thumbnails.add(thumbnailRecord);
+            }
         }
+        if (thumbnails.isEmpty()) {
+            return;
+        }
+        AtomicInteger index = new AtomicInteger(0);
+        for (int i = 0; i < Math.min(PRELOAD_THUMBNAIL_CONCURRENCY, thumbnails.size()); i++) {
+            preloadNextThumbnail(thumbnails, index);
+        }
+    }
+
+    private void preloadNextThumbnail(List<FileRecord> thumbnails, AtomicInteger index) {
+        int i = index.getAndIncrement();
+        if (i >= thumbnails.size()) {
+            return;
+        }
+        FileRecord thumbnailRecord = thumbnails.get(i);
+        downloadThumbnail(thumbnailRecord.chatId(), thumbnailRecord.messageId(), thumbnailRecord)
+                .onFailure(err -> log.debug("[%s] Preload thumbnail failed for %s: %s"
+                        .formatted(getRootId(), thumbnailRecord.uniqueId(), err.getMessage())))
+                .onComplete(_ -> preloadNextThumbnail(thumbnails, index));
     }
 
     public Future<Void> cancelDownload(Integer fileId) {

--- a/api/src/main/java/telegram/files/TelegramVerticle.java
+++ b/api/src/main/java/telegram/files/TelegramVerticle.java
@@ -201,7 +201,10 @@ public class TelegramVerticle extends AbstractVerticle {
             return (Objects.equals(filter.get("downloadStatus"), FileRecord.DownloadStatus.idle.name()) ?
                     this.getIdleChatFiles(searchChatMessages, 0) :
                     client.execute(searchChatMessages))
-                    .compose(t -> TelegramConverter.convertFiles(this.telegramRecord.id(), t));
+                    .compose(t -> {
+                        preloadThumbnails(t);
+                        return TelegramConverter.convertFiles(this.telegramRecord.id(), t);
+                    });
         }
     }
 
@@ -370,6 +373,28 @@ public class TelegramVerticle extends AbstractVerticle {
                         log.debug("[%s] Download thumbnail: %s".formatted(this.getRootId(), thumbnailRecord.uniqueId()));
                     }
                 });
+    }
+
+    /**
+     * Eagerly downloads the lightweight thumbnails for the given messages so previews are crisp
+     * while browsing, without having to download the full media. Fire-and-forget: already
+     * downloaded thumbnails are skipped by {@link #downloadThumbnail}.
+     */
+    private void preloadThumbnails(TdApi.FoundChatMessages foundChatMessages) {
+        if (foundChatMessages == null || foundChatMessages.messages == null || telegramRecord == null) {
+            return;
+        }
+        for (TdApi.Message message : foundChatMessages.messages) {
+            TdApiHelp.getFileHandler(message).ifPresent(fileHandler -> {
+                FileRecord thumbnailRecord = fileHandler.convertThumbnailRecord(telegramRecord.id());
+                if (thumbnailRecord == null) {
+                    return;
+                }
+                downloadThumbnail(message.chatId, message.id, thumbnailRecord)
+                        .onFailure(err -> log.debug("[%s] Preload thumbnail failed for message %d: %s"
+                                .formatted(getRootId(), message.id, err.getMessage())));
+            });
+        }
     }
 
     public Future<Void> cancelDownload(Integer fileId) {
@@ -672,6 +697,9 @@ public class TelegramVerticle extends AbstractVerticle {
         if ("completed".equals(fileUpdated.getString("downloadStatus"))) {
             DataVerticle.fileRepository.getByUniqueId(file.remote.uniqueId)
                     .compose(mainFileRecord -> {
+                        if (mainFileRecord != null) {
+                            statusData.put("type", mainFileRecord.type());
+                        }
                         if (mainFileRecord != null && mainFileRecord.thumbnailUniqueId() != null) {
                             return FileRecordRetriever.getThumbnails(List.of(mainFileRecord))
                                     .map(thumbnailMap -> {

--- a/api/src/main/java/telegram/files/TransferVerticle.java
+++ b/api/src/main/java/telegram/files/TransferVerticle.java
@@ -93,6 +93,10 @@ public class TransferVerticle extends AbstractVerticle {
                     return;
                 }
                 FileRecord fileRecord = Future.await(DataVerticle.fileRepository.getByUniqueId((String) data.get("uniqueId")));
+                if (fileRecord == null || "thumbnail".equals(fileRecord.type())) {
+                    // Thumbnails are internal preview files; never transfer them.
+                    return;
+                }
 
                 SettingAutoRecords.Automation automation = null;
                 if (fileRecord.threadChatId() != 0 && fileRecord.messageThreadId() != 0 && fileRecord.threadChatId() == fileRecord.chatId()) {
@@ -150,6 +154,10 @@ public class TransferVerticle extends AbstractVerticle {
 
             int count = 0;
             for (FileRecord fileRecord : files) {
+                if ("thumbnail".equals(fileRecord.type())) {
+                    // Thumbnails are internal preview files; never transfer them.
+                    continue;
+                }
                 if (addWaitingTransferFile(fileRecord)) {
                     count++;
                 }

--- a/web/src/hooks/use-files.ts
+++ b/web/src/hooks/use-files.ts
@@ -10,7 +10,7 @@ import useSWRInfinite from "swr/infinite";
 import { useWebsocket } from "@/hooks/use-websocket";
 import { WebSocketMessageType } from "@/lib/websocket-types";
 import { useLocalStorage } from "@/hooks/use-local-storage";
-import { useDebounce } from "use-debounce";
+import { useDebounce, useDebouncedCallback } from "use-debounce";
 
 const DEFAULT_FILTERS: FileFilter = {
   search: "",
@@ -122,6 +122,12 @@ export function useFiles(
     maxWait: 1000,
   });
 
+  // A thumbnail finished downloading in the background; refetch so the list picks up the
+  // crisp thumbnailFile. Debounced to coalesce the bursts that happen while browsing.
+  const debouncedThumbnailRefetch = useDebouncedCallback(() => {
+    void mutate();
+  }, 1500);
+
   useEffect(() => {
     if (lastJsonMessage?.type !== WebSocketMessageType.FILE_STATUS) {
       return;
@@ -136,7 +142,13 @@ export function useFiles(
       transferStatus?: TransferStatus;
       thumbnailFile?: Thumbnail;
       removed?: boolean;
+      type?: string;
     };
+
+    if (data.type === "thumbnail") {
+      debouncedThumbnailRefetch();
+      return;
+    }
 
     if (data.removed) {
       setLatestFileStatus((prev) => ({


### PR DESCRIPTION
## Motivation
Before a file is downloaded, previews relied on Telegram's base64 *minithumbnail* (~10px), which is a blurred placeholder by design — so previews looked very low quality.

## Changes
- `PhotoHandler` now exposes a small (~320px `m`) photo size as a real, downloadable thumbnail, so photos get a crisp preview thumbnail just like videos already do.
- Browsing a chat eagerly downloads each media item's lightweight thumbnail (~10–30 KB) in the background (`preloadThumbnails`), reusing the existing `downloadThumbnail` path. Already-downloaded thumbnails are skipped (fire-and-forget, de-duplicated).
- `convertFiles` links the downloaded thumbnail to its file using the live message's thumbnail uniqueId, so previews work even for files not yet tracked in the DB.
- `FILE_STATUS` events now carry the file `type`; the web client refetches (debounced) when a thumbnail finishes downloading, so crisp previews appear automatically without a manual reload.
- **Never transfer thumbnails**: thumbnails are internal preview files, but they were eligible for the transfer queue and would be moved to the destination (e.g. `.../thumbnail/`). Since transfers are serial, a flood of thumbnails pushed real media to the back of the FIFO queue. Thumbnails are now skipped in both transfer entry points (completion event + history scan).

## Notes
- No new dependencies. Fully downloaded images keep rendering at full resolution as before.

## Testing
Verified on a running instance: previews sharpen within ~1–2 s of opening a chat as thumbnails arrive; previously visited chats show crisp previews immediately; real media transfers are no longer delayed behind thumbnails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)