### PR TITLE
✨ feat: optional post caption in transferred file name

### DIFF
--- a/api/src/main/java/telegram/files/Transfer.java
+++ b/api/src/main/java/telegram/files/Transfer.java
@@ -22,6 +22,7 @@ import java.nio.file.Path;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
+import java.util.regex.Pattern;
 
 public abstract class Transfer {
 
@@ -44,6 +45,13 @@ public abstract class Transfer {
     private FileRecord transferRecord;
 
     private static final int MAX_CAPTION_NAME_LENGTH = 80;
+
+    // Keep the whole file name under common filesystem limits (~255), with margin for multibyte chars.
+    private static final int MAX_FILENAME_LENGTH = 200;
+
+    private static final Pattern ILLEGAL_FILENAME_CHARS = Pattern.compile("[\\\\/:*?\"<>|\\r\\n\\t]");
+
+    private static final Pattern WHITESPACE = Pattern.compile("\\s+");
 
     public Transfer(SettingAutoRecords.TransferRule transferRule) {
         this.destination = transferRule.destination;
@@ -145,8 +153,11 @@ public abstract class Transfer {
 
     /**
      * Builds the destination file name. When {@link #useCaptionName} is enabled and the file has a
-     * caption, the caption is appended before the extension: {@code <originalBaseName>_<caption>.<ext>}.
-     * Falls back to the original file name when disabled or when there is no usable caption.
+     * caption, the caption is appended before the extension: {@code <originalBaseName>_<caption>.<ext>},
+     * capped at {@link #MAX_FILENAME_LENGTH}. Falls back to the original file name when disabled or
+     * when there is no usable caption.
+     * <p>Note: the GROUP_BY_AI policy may instead use a file name chosen by the model (when it returns
+     * a path that already includes a file name); in that case the caption is not appended.
      */
     protected String buildFileName(FileRecord fileRecord) {
         String originalName = FileUtil.getName(fileRecord.localPath());
@@ -159,9 +170,15 @@ public abstract class Transfer {
         }
         String extension = FileUtil.extName(originalName);
         String baseName = FileUtil.mainName(originalName);
-        return StrUtil.isBlank(extension)
-                ? "%s_%s".formatted(baseName, caption)
-                : "%s_%s.%s".formatted(baseName, caption, extension);
+        String stem = "%s_%s".formatted(baseName, caption);
+        String suffix = StrUtil.isBlank(extension) ? "" : "." + extension;
+        // Cap the whole file name (preserving the extension) so a long original name plus the
+        // caption can't exceed common filesystem limits.
+        int maxStem = MAX_FILENAME_LENGTH - suffix.length();
+        if (maxStem > 0 && stem.length() > maxStem) {
+            stem = stem.substring(0, maxStem).trim();
+        }
+        return stem + suffix;
     }
 
     private static String sanitizeForFileName(String text) {
@@ -169,8 +186,8 @@ public abstract class Transfer {
             return "";
         }
         // Replace characters that are illegal/problematic in file names and collapse whitespace.
-        String sanitized = text.replaceAll("[\\\\/:*?\"<>|\\r\\n\\t]", " ")
-                .replaceAll("\\s+", " ")
+        String sanitized = WHITESPACE.matcher(ILLEGAL_FILENAME_CHARS.matcher(text).replaceAll(" "))
+                .replaceAll(" ")
                 .trim();
         if (sanitized.length() > MAX_CAPTION_NAME_LENGTH) {
             sanitized = sanitized.substring(0, MAX_CAPTION_NAME_LENGTH).trim();
@@ -250,7 +267,8 @@ public abstract class Transfer {
             }
             log.debug("File {} classified to {} by AI, reason: {}", fileRecord.id(), result.path, result.reason);
             String name = buildFileName(fileRecord);
-            // Check if the path contains file extension
+            // If the model returned a path that already includes a file name (has an extension),
+            // that AI-chosen name is used as-is — the caption is intentionally not appended here.
             if (StrUtil.isNotBlank(FileUtil.extName(result.path))) {
                 name = "";
             }

--- a/api/src/main/java/telegram/files/Transfer.java
+++ b/api/src/main/java/telegram/files/Transfer.java
@@ -35,17 +35,22 @@ public abstract class Transfer {
 
     public boolean transferHistory;
 
+    public boolean useCaptionName;
+
     public JsonObject extra;
 
     public Consumer<TransferStatusUpdated> transferStatusUpdated;
 
     private FileRecord transferRecord;
 
+    private static final int MAX_CAPTION_NAME_LENGTH = 80;
+
     public Transfer(SettingAutoRecords.TransferRule transferRule) {
         this.destination = transferRule.destination;
         this.transferPolicy = transferRule.transferPolicy;
         this.duplicationPolicy = transferRule.duplicationPolicy;
         this.transferHistory = transferRule.transferHistory;
+        this.useCaptionName = transferRule.useCaptionName;
         this.extra = transferRule.extra != null ? transferRule.extra : new JsonObject();
     }
 
@@ -63,6 +68,7 @@ public abstract class Transfer {
                || this.transferPolicy != transferRule.transferPolicy
                || this.duplicationPolicy != transferRule.duplicationPolicy
                || this.transferHistory != transferRule.transferHistory
+               || this.useCaptionName != transferRule.useCaptionName
                || !Objects.equals(this.extra, transferRule.extra);
     }
 
@@ -137,6 +143,41 @@ public abstract class Transfer {
         return Path.of(parent, "%s-%d.%s".formatted(baseName, i, extension)).toString();
     }
 
+    /**
+     * Builds the destination file name. When {@link #useCaptionName} is enabled and the file has a
+     * caption, the caption is appended before the extension: {@code <originalBaseName>_<caption>.<ext>}.
+     * Falls back to the original file name when disabled or when there is no usable caption.
+     */
+    protected String buildFileName(FileRecord fileRecord) {
+        String originalName = FileUtil.getName(fileRecord.localPath());
+        if (!useCaptionName || StrUtil.isBlank(fileRecord.caption())) {
+            return originalName;
+        }
+        String caption = sanitizeForFileName(fileRecord.caption());
+        if (StrUtil.isBlank(caption)) {
+            return originalName;
+        }
+        String extension = FileUtil.extName(originalName);
+        String baseName = FileUtil.mainName(originalName);
+        return StrUtil.isBlank(extension)
+                ? "%s_%s".formatted(baseName, caption)
+                : "%s_%s.%s".formatted(baseName, caption, extension);
+    }
+
+    private static String sanitizeForFileName(String text) {
+        if (text == null) {
+            return "";
+        }
+        // Replace characters that are illegal/problematic in file names and collapse whitespace.
+        String sanitized = text.replaceAll("[\\\\/:*?\"<>|\\r\\n\\t]", " ")
+                .replaceAll("\\s+", " ")
+                .trim();
+        if (sanitized.length() > MAX_CAPTION_NAME_LENGTH) {
+            sanitized = sanitized.substring(0, MAX_CAPTION_NAME_LENGTH).trim();
+        }
+        return sanitized;
+    }
+
     public FileRecord getTransferRecord() {
         return transferRecord;
     }
@@ -151,7 +192,7 @@ public abstract class Transfer {
 
         @Override
         protected String getTransferPath(FileRecord fileRecord) {
-            String name = FileUtil.getName(fileRecord.localPath());
+            String name = buildFileName(fileRecord);
             return Path.of(destination,
                     Convert.toStr(fileRecord.telegramId()),
                     Convert.toStr(fileRecord.chatId()),
@@ -168,7 +209,7 @@ public abstract class Transfer {
 
         @Override
         protected String getTransferPath(FileRecord fileRecord) {
-            String name = FileUtil.getName(fileRecord.localPath());
+            String name = buildFileName(fileRecord);
             return Path.of(destination,
                     fileRecord.type(),
                     name
@@ -208,7 +249,7 @@ public abstract class Transfer {
                 throw new IllegalStateException("Invalid classification result from AI: " + result);
             }
             log.debug("File {} classified to {} by AI, reason: {}", fileRecord.id(), result.path, result.reason);
-            String name = FileUtil.getName(fileRecord.localPath());
+            String name = buildFileName(fileRecord);
             // Check if the path contains file extension
             if (StrUtil.isNotBlank(FileUtil.extName(result.path))) {
                 name = "";
@@ -230,7 +271,7 @@ public abstract class Transfer {
 
         @Override
         protected String getTransferPath(FileRecord fileRecord) {
-            String name = FileUtil.getName(fileRecord.localPath());
+            String name = buildFileName(fileRecord);
             return Path.of(destination, name).toString();
         }
     }

--- a/api/src/main/java/telegram/files/repository/SettingAutoRecords.java
+++ b/api/src/main/java/telegram/files/repository/SettingAutoRecords.java
@@ -118,6 +118,9 @@ public class SettingAutoRecords {
 
         public Transfer.DuplicationPolicy duplicationPolicy;
 
+        // When true, the post caption is appended to the destination file name.
+        public boolean useCaptionName;
+
         public JsonObject extra;
     }
 

--- a/web/src/components/automation-dialog.tsx
+++ b/web/src/components/automation-dialog.tsx
@@ -43,6 +43,7 @@ const DEFAULT_AUTO: Auto = {
       destination: "",
       transferPolicy: "GROUP_BY_CHAT",
       duplicationPolicy: "OVERWRITE",
+      useCaptionName: false,
       extra: {},
     },
   },

--- a/web/src/components/automation-form.tsx
+++ b/web/src/components/automation-form.tsx
@@ -10,7 +10,7 @@ import {
   TransferPolices,
   type TransferPolicy,
 } from "@/lib/types";
-import React, { useMemo, useState } from "react";
+import React, { useId, useMemo, useState } from "react";
 import {
   Accordion,
   AccordionContent,
@@ -357,6 +357,7 @@ interface TransferRuleProps {
 }
 
 function TransferRule({ value, onChange }: TransferRuleProps) {
+  const captionNameId = useId();
   const handleTransferRuleChange = (changes: Partial<AutoTransferRule>) => {
     onChange({
       ...value,
@@ -456,9 +457,9 @@ function TransferRule({ value, onChange }: TransferRuleProps) {
 
             <div className="rounded-md border p-4">
               <div className="flex items-center justify-between">
-                <Label htmlFor="use-caption-name">Add caption to file name</Label>
+                <Label htmlFor={captionNameId}>Add caption to file name</Label>
                 <Switch
-                  id="use-caption-name"
+                  id={captionNameId}
                   checked={value.useCaptionName ?? false}
                   onCheckedChange={(checked) =>
                     handleTransferRuleChange({ useCaptionName: checked })

--- a/web/src/components/automation-form.tsx
+++ b/web/src/components/automation-form.tsx
@@ -453,6 +453,24 @@ function TransferRule({ value, onChange }: TransferRuleProps) {
                 location.
               </p>
             </div>
+
+            <div className="rounded-md border p-4">
+              <div className="flex items-center justify-between">
+                <Label htmlFor="use-caption-name">Add caption to file name</Label>
+                <Switch
+                  id="use-caption-name"
+                  checked={value.useCaptionName ?? false}
+                  onCheckedChange={(checked) =>
+                    handleTransferRuleChange({ useCaptionName: checked })
+                  }
+                />
+              </div>
+              <p className="mt-2 text-xs text-muted-foreground">
+                Append the post caption to the transferred file name (e.g.
+                name_caption.jpg). Falls back to the original name when the post
+                has no caption.
+              </p>
+            </div>
           </div>
         </AccordionContent>
       </AccordionItem>

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -193,6 +193,7 @@ export type AutoTransferRule = {
   destination: string;
   transferPolicy: TransferPolicy;
   duplicationPolicy: DuplicationPolicy;
+  useCaptionName?: boolean;
   extra: Record<string, any>
 };
 


### PR DESCRIPTION
## Motivation
When transferring downloaded media to a destination, the file keeps its original (often opaque) name. This adds the option to include the post caption in the transferred file name, which makes the saved files self-descriptive.

## Changes
- New **opt-in** toggle **"Add caption to file name"** in the automation Transfer settings (`TransferRule.useCaptionName`, default **off**).
- When enabled, the post caption is appended to the destination name as `originalName_caption.ext`. The caption is sanitised (illegal filename characters and newlines stripped, whitespace collapsed) and truncated, and the **whole file name is capped** (preserving the extension) to stay within filesystem limits. Falls back to the original name when disabled or when the post has no caption.
- Applies to the Direct / Group by Chat / Group by Type policies, and to Group by AI **except** when the model returns a path that already includes a file name — in that case the AI-chosen name is used as-is and the caption is not appended.

## Notes
- No new dependencies. Behaviour is unchanged unless the toggle is enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)