### PR TITLE
✨ feat: TDLib connection-aware auto-reconnect

### DIFF
--- a/api/src/main/java/telegram/files/EventPayload.java
+++ b/api/src/main/java/telegram/files/EventPayload.java
@@ -13,6 +13,8 @@ public record EventPayload(int type, String code, Object data, long timestamp) {
 
     public static final int TYPE_FILE_STATUS = 5;
 
+    public static final int TYPE_CONNECTION = 6;
+
     public static EventPayload build(int type, Object data) {
         return new EventPayload(type, null, data, System.currentTimeMillis());
     }

--- a/api/src/main/java/telegram/files/TelegramUpdateHandler.java
+++ b/api/src/main/java/telegram/files/TelegramUpdateHandler.java
@@ -21,12 +21,18 @@ public class TelegramUpdateHandler implements Client.ResultHandler {
 
     private Consumer<TdApi.Message> onMessageReceived;
 
+    private Consumer<TdApi.ConnectionState> onConnectionStateUpdated;
+
     @Override
     public void onResult(TdApi.Object object) {
         switch (object.getConstructor()) {
             case TdApi.UpdateAuthorizationState.CONSTRUCTOR:
                 if (onAuthorizationStateUpdated != null)
                     onAuthorizationStateUpdated.accept(((TdApi.UpdateAuthorizationState) object).authorizationState);
+                break;
+            case TdApi.UpdateConnectionState.CONSTRUCTOR:
+                if (onConnectionStateUpdated != null)
+                    onConnectionStateUpdated.accept(((TdApi.UpdateConnectionState) object).state);
                 break;
             case TdApi.UpdateFile.CONSTRUCTOR:
                 if (onFileUpdated != null)
@@ -74,5 +80,9 @@ public class TelegramUpdateHandler implements Client.ResultHandler {
 
     public void setOnMessageReceived(Consumer<TdApi.Message> onMessageReceived) {
         this.onMessageReceived = onMessageReceived;
+    }
+
+    public void setOnConnectionStateUpdated(Consumer<TdApi.ConnectionState> onConnectionStateUpdated) {
+        this.onConnectionStateUpdated = onConnectionStateUpdated;
     }
 }

--- a/api/src/main/java/telegram/files/TelegramVerticle.java
+++ b/api/src/main/java/telegram/files/TelegramVerticle.java
@@ -59,6 +59,8 @@ public class TelegramVerticle extends AbstractVerticle {
 
     private long downloadStatusReconciliationTimerId;
 
+    public TdApi.ConnectionState lastConnectionState;
+
     private long lastFileEventTime;
 
     private long lastFileDownloadEventTime;
@@ -98,6 +100,7 @@ public class TelegramVerticle extends AbstractVerticle {
         telegramUpdateHandler.setOnFileDownloadsUpdated(this::onFileDownloadsUpdated);
         telegramUpdateHandler.setOnChatUpdated(telegramChats::onChatUpdated);
         telegramUpdateHandler.setOnMessageReceived(this::onMessageReceived);
+        telegramUpdateHandler.setOnConnectionStateUpdated(this::onConnectionStateUpdated);
 
         client.initialize(telegramUpdateHandler, this::handleException, this::handleException);
         Future.all(initEventConsumer(), initAvgSpeed())
@@ -824,6 +827,28 @@ public class TelegramVerticle extends AbstractVerticle {
                     }
                 })
                 .onFailure(e -> log.error("[%s] Failed to get downloading files for reconciliation: %s".formatted(getRootId(), e.getMessage())));
+    }
+
+    private void onConnectionStateUpdated(TdApi.ConnectionState connectionState) {
+        this.lastConnectionState = connectionState;
+        log.debug("[%s] Connection state: %s".formatted(getRootId(), connectionState.getClass().getSimpleName()));
+        if (connectionState.getConstructor() == TdApi.ConnectionStateWaitingForNetwork.CONSTRUCTOR) {
+            // Tell TDLib the network is available so it retries connecting instead of waiting indefinitely.
+            client.execute(new TdApi.SetNetworkType(new TdApi.NetworkTypeOther()), true);
+        }
+        sendEvent(EventPayload.build(EventPayload.TYPE_CONNECTION, new JsonObject()
+                .put("state", connectionStateName(connectionState))));
+    }
+
+    private static String connectionStateName(TdApi.ConnectionState state) {
+        return switch (state.getConstructor()) {
+            case TdApi.ConnectionStateReady.CONSTRUCTOR -> "ready";
+            case TdApi.ConnectionStateConnecting.CONSTRUCTOR -> "connecting";
+            case TdApi.ConnectionStateConnectingToProxy.CONSTRUCTOR -> "connectingToProxy";
+            case TdApi.ConnectionStateUpdating.CONSTRUCTOR -> "updating";
+            case TdApi.ConnectionStateWaitingForNetwork.CONSTRUCTOR -> "waitingForNetwork";
+            default -> "unknown";
+        };
     }
 
     private void onAuthorizationStateUpdated(TdApi.AuthorizationState authorizationState) {

--- a/api/src/main/java/telegram/files/TelegramVerticle.java
+++ b/api/src/main/java/telegram/files/TelegramVerticle.java
@@ -59,7 +59,7 @@ public class TelegramVerticle extends AbstractVerticle {
 
     private long downloadStatusReconciliationTimerId;
 
-    public TdApi.ConnectionState lastConnectionState;
+    private volatile TdApi.ConnectionState lastConnectionState;
 
     private long lastFileEventTime;
 

--- a/web/src/components/header.tsx
+++ b/web/src/components/header.tsx
@@ -85,7 +85,24 @@ export function Header() {
                   className={
                     connectionStatus !== "Open" ? "cursor-pointer" : undefined
                   }
+                  role={connectionStatus !== "Open" ? "button" : undefined}
+                  tabIndex={connectionStatus !== "Open" ? 0 : undefined}
+                  aria-label={
+                    connectionStatus !== "Open"
+                      ? "Reconnect live updates"
+                      : undefined
+                  }
                   onClick={connectionStatus !== "Open" ? reconnect : undefined}
+                  onKeyDown={
+                    connectionStatus !== "Open"
+                      ? (e) => {
+                          if (e.key === "Enter" || e.key === " ") {
+                            e.preventDefault();
+                            reconnect();
+                          }
+                        }
+                      : undefined
+                  }
                 >
                   {connectionStatus === "Open" ? (
                     <ChevronsLeftRightEllipsisIcon className="mr-1 h-4 w-4" />

--- a/web/src/components/header.tsx
+++ b/web/src/components/header.tsx
@@ -28,7 +28,8 @@ import { useSettings } from "@/hooks/use-settings";
 
 export function Header() {
   const useTelegramAccountProps = useTelegramAccount();
-  const { connectionStatus, accountDownloadSpeed } = useWebsocket();
+  const { connectionStatus, accountDownloadSpeed, reconnect, telegramConnectionState } =
+    useWebsocket();
   const { settings } = useSettings();
   const isMobile = useIsMobile();
   const [showMore, setShowMore] = useState(false);
@@ -70,11 +71,21 @@ export function Header() {
             )}
 
             {connectionStatus && (
-              <TooltipWrapper content="WebSocket connection status">
+              <TooltipWrapper
+                content={
+                  connectionStatus === "Open"
+                    ? "Live updates connected"
+                    : "Live updates disconnected — click to reconnect"
+                }
+              >
                 <Badge
                   variant={
                     connectionStatus === "Open" ? "default" : "secondary"
                   }
+                  className={
+                    connectionStatus !== "Open" ? "cursor-pointer" : undefined
+                  }
+                  onClick={connectionStatus !== "Open" ? reconnect : undefined}
                 >
                   {connectionStatus === "Open" ? (
                     <ChevronsLeftRightEllipsisIcon className="mr-1 h-4 w-4" />
@@ -82,6 +93,15 @@ export function Header() {
                     <UnplugIcon className="mr-1 h-4 w-4" />
                   )}
                   {connectionStatus}
+                </Badge>
+              </TooltipWrapper>
+            )}
+
+            {telegramConnectionState && telegramConnectionState !== "ready" && (
+              <TooltipWrapper content="Telegram connection state">
+                <Badge variant="secondary">
+                  <UnplugIcon className="mr-1 h-4 w-4" />
+                  Telegram: {telegramConnectionState}
                 </Badge>
               </TooltipWrapper>
             )}

--- a/web/src/components/mobile/mobile-header.tsx
+++ b/web/src/components/mobile/mobile-header.tsx
@@ -185,8 +185,25 @@ function MenuDrawer() {
                     className={
                       connectionStatus !== "Open" ? "cursor-pointer" : undefined
                     }
+                    role={connectionStatus !== "Open" ? "button" : undefined}
+                    tabIndex={connectionStatus !== "Open" ? 0 : undefined}
+                    aria-label={
+                      connectionStatus !== "Open"
+                        ? "Reconnect live updates"
+                        : undefined
+                    }
                     onClick={
                       connectionStatus !== "Open" ? reconnect : undefined
+                    }
+                    onKeyDown={
+                      connectionStatus !== "Open"
+                        ? (e) => {
+                            if (e.key === "Enter" || e.key === " ") {
+                              e.preventDefault();
+                              reconnect();
+                            }
+                          }
+                        : undefined
                     }
                   >
                     {connectionStatus === "Open" ? (

--- a/web/src/components/mobile/mobile-header.tsx
+++ b/web/src/components/mobile/mobile-header.tsx
@@ -94,7 +94,8 @@ export function MobileHeader() {
 function MenuDrawer() {
   const useTelegramAccountProps = useTelegramAccount();
   const { chat } = useTelegramChat();
-  const { connectionStatus } = useWebsocket();
+  const { connectionStatus, reconnect, telegramConnectionState } =
+    useWebsocket();
   const [layout, setLayout] = useLocalStorage<"detailed" | "gallery">(
     "telegramFileLayout",
     "detailed",
@@ -176,18 +177,34 @@ function MenuDrawer() {
                 </div>
               </div>
               <div className="flex items-center justify-between gap-2 py-4">
-                <Badge
-                  variant={
-                    connectionStatus === "Open" ? "default" : "secondary"
-                  }
-                >
-                  {connectionStatus === "Open" ? (
-                    <ChevronsLeftRightEllipsisIcon className="mr-1 h-4 w-4" />
-                  ) : (
-                    <UnplugIcon className="mr-1 h-4 w-4" />
-                  )}
-                  {connectionStatus}
-                </Badge>
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge
+                    variant={
+                      connectionStatus === "Open" ? "default" : "secondary"
+                    }
+                    className={
+                      connectionStatus !== "Open" ? "cursor-pointer" : undefined
+                    }
+                    onClick={
+                      connectionStatus !== "Open" ? reconnect : undefined
+                    }
+                  >
+                    {connectionStatus === "Open" ? (
+                      <ChevronsLeftRightEllipsisIcon className="mr-1 h-4 w-4" />
+                    ) : (
+                      <UnplugIcon className="mr-1 h-4 w-4" />
+                    )}
+                    {connectionStatus}
+                  </Badge>
+
+                  {telegramConnectionState &&
+                    telegramConnectionState !== "ready" && (
+                      <Badge variant="secondary">
+                        <UnplugIcon className="mr-1 h-4 w-4" />
+                        Telegram: {telegramConnectionState}
+                      </Badge>
+                    )}
+                </div>
 
                 <ThemeToggleButton />
                 <SettingsDialog />

--- a/web/src/hooks/use-websocket.tsx
+++ b/web/src/hooks/use-websocket.tsx
@@ -27,6 +27,8 @@ interface WebsocketContextType {
   connectionStatus: string;
   isReady: boolean;
   accountDownloadSpeed: number;
+  reconnect: () => void;
+  telegramConnectionState: string | null;
 }
 
 const WebSocketContext = createContext<WebsocketContextType | undefined>(
@@ -53,15 +55,47 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({
     maxWait: 1000,
   });
 
+  const [reconnectNonce, setReconnectNonce] = useState(0);
+  const [telegramConnectionState, setTelegramConnectionState] = useState<
+    string | null
+  >(null);
+
   const { sendMessage, lastJsonMessage, readyState } =
     useWebSocket<WebSocketMessage>(
-      `${WS_URL}?telegramId=${searchParams.get("id") ?? ""}`,
+      `${WS_URL}?telegramId=${searchParams.get("id") ?? ""}&_r=${reconnectNonce}`,
       {
-        shouldReconnect: (closeEvent) => true,
-        reconnectAttempts: 3,
-        reconnectInterval: 3000,
+        // Keep retrying (essentially) forever with exponential backoff capped at 30s, and also
+        // retry on error events — so a transient outage recovers on its own instead of giving up.
+        shouldReconnect: () => true,
+        reconnectAttempts: 999,
+        reconnectInterval: (attemptNumber) =>
+          Math.min(1000 * 2 ** attemptNumber, 30000),
+        retryOnError: true,
       },
     );
+
+  // Force a fresh connection (resets the backoff/attempt counter); used by the manual
+  // "reconnect" affordance and when the network/focus comes back.
+  const reconnect = useCallback(() => {
+    setReconnectNonce((n) => n + 1);
+  }, []);
+
+  useEffect(() => {
+    const maybeReconnect = () => {
+      if (
+        readyState !== ReadyState.OPEN &&
+        readyState !== ReadyState.CONNECTING
+      ) {
+        setReconnectNonce((n) => n + 1);
+      }
+    };
+    window.addEventListener("online", maybeReconnect);
+    window.addEventListener("focus", maybeReconnect);
+    return () => {
+      window.removeEventListener("online", maybeReconnect);
+      window.removeEventListener("focus", maybeReconnect);
+    };
+  }, [readyState]);
 
   const connectionStatus = {
     [ReadyState.CONNECTING]: "Connecting",
@@ -84,6 +118,11 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({
         const payload: WebSocketMessage = lastJsonMessage;
         const timestamp = payload.timestamp;
         switch (payload.type) {
+          case WebSocketMessageType.CONNECTION:
+            setTelegramConnectionState(
+              (payload.data as { state?: string })?.state ?? null,
+            );
+            break;
           case WebSocketMessageType.ERROR:
             toast({
               variant: "error",
@@ -153,6 +192,8 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({
         connectionStatus,
         isReady,
         accountDownloadSpeed: debounceSpeed,
+        reconnect,
+        telegramConnectionState,
       }}
     >
       {children}

--- a/web/src/lib/websocket-types.ts
+++ b/web/src/lib/websocket-types.ts
@@ -12,6 +12,7 @@ export const WebSocketMessageType = {
   FILE_UPDATE: 3,
   FILE_DOWNLOAD: 4,
   FILE_STATUS: 5,
+  CONNECTION: 6,
 };
 
 export type TelegramError = {


### PR DESCRIPTION
## Motivation
After a network blip the app could stay effectively disconnected until a manual restart, and the UI gave no indication of the real Telegram connection state (the status badge only reflects the browser↔server WebSocket).

## Changes
- Handle TDLib `UpdateConnectionState`. On `ConnectionStateWaitingForNetwork` the app calls `setNetworkType(NetworkTypeOther)` so TDLib retries connecting promptly instead of waiting indefinitely.
- Broadcast the Telegram connection state to the web client via a new `CONNECTION` event.
- Frontend WebSocket now reconnects essentially forever with exponential backoff (capped at 30s) and `retryOnError`, instead of giving up after 3 attempts (~9s). It also reconnects on network `online` / window `focus`.
- The connection badge is clickable to force a reconnect, and the header shows the real Telegram connection state when it isn't `ready`.

## Notes
- Additive only; no new dependencies. Independent of the existing download-status reconciliation (does not touch it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)