### PR TITLE
🐛 fix: avoid ConcurrentModificationException in AvgSpeed

### DIFF
--- a/api/src/main/java/telegram/files/AvgSpeed.java
+++ b/api/src/main/java/telegram/files/AvgSpeed.java
@@ -3,13 +3,16 @@ package telegram.files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
+import java.util.concurrent.ConcurrentNavigableMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.stream.Collectors;
 
 public class AvgSpeed {
     private final int interval;
 
-    private final TreeMap<Long, SpeedPoint> speedPoints;
+    // Concurrent: update() runs on TDLib's callback thread while getSpeedStats() runs on a Vert.x
+    // timer thread — a plain TreeMap threw ConcurrentModificationException when read while modified.
+    private final ConcurrentNavigableMap<Long, SpeedPoint> speedPoints;
 
     private final int smoothingWindowSize;
 
@@ -29,7 +32,7 @@ public class AvgSpeed {
 
     public AvgSpeed(int interval, int smoothingWindowSize) {
         this.interval = interval;
-        this.speedPoints = new TreeMap<>();
+        this.speedPoints = new ConcurrentSkipListMap<>();
         this.smoothingWindowSize = smoothingWindowSize;
     }
 


### PR DESCRIPTION
## Problem

`AvgSpeed.update()` is called from TDLib's update-callback thread while `getSpeedStats()` (and `getMaxSpeed/getMedianSpeed/getSpeed`) run from a Vert.x periodic timer. They share a plain `TreeMap`, which is not thread-safe, so streaming over its values while it is being modified throws:

```
java.util.ConcurrentModificationException
    at java.base/java.util.TreeMap$ValueSpliterator.forEachRemaining(...)
    ...
    at telegram.files.AvgSpeed.getMaxSpeed(AvgSpeed.java:195)
    at telegram.files.AvgSpeed.getSpeedStats(AvgSpeed.java:218)
    at telegram.files.TelegramVerticle.handleSaveAvgSpeed(...)
```

## Fix

Use a `ConcurrentSkipListMap` instead of `TreeMap`. It keeps the same `NavigableMap` semantics used here (`headMap().clear()`, `firstEntry`/`lastEntry`, ordered `values()`) but offers weakly-consistent, non-throwing iteration, so concurrent reads during updates no longer crash.

No behavioural change to the computed statistics.