### PR TITLE
🐛 fix: tolerate concurrent file_record create race

### DIFF
--- a/api/src/main/java/telegram/files/TelegramVerticle.java
+++ b/api/src/main/java/telegram/files/TelegramVerticle.java
@@ -1472,6 +1472,7 @@ public class TelegramVerticle extends AbstractVerticle {
                             .withThreadInfo(messageThreadInfo);
 
                     return DataVerticle.fileRepository.create(fileRecord)
+                            .onFailure(err -> log.error(err, "Failed to create file record: %s".formatted(file.remote.uniqueId)))
                             .compose(_ -> DataVerticle.fileRepository.updateDownloadStatus(
                                     file.id,
                                     file.remote.uniqueId,

--- a/api/src/main/java/telegram/files/repository/impl/FileRepositoryImpl.java
+++ b/api/src/main/java/telegram/files/repository/impl/FileRepositoryImpl.java
@@ -64,8 +64,7 @@ public class FileRepositoryImpl extends AbstractSqlRepository implements FileRep
                         return this.updateAlbumDataByMediaAlbumId(fileRecord.mediaAlbumId(), fileRecord.caption(), fileRecord.reactionCount()).map(r);
                     }
                 })
-                .onSuccess(r -> log.trace("Successfully created file record: %s".formatted(fileRecord.id())))
-                .onFailure(err -> log.error("Failed to create file record: %s".formatted(err.getMessage())));
+                .onSuccess(r -> log.trace("Successfully created file record: %s".formatted(fileRecord.id())));
     }
 
     @Override
@@ -75,7 +74,18 @@ public class FileRepositoryImpl extends AbstractSqlRepository implements FileRep
                     if (record != null) {
                         return Future.succeededFuture(false);
                     }
-                    return this.create(fileRecord).map(true);
+                    return this.create(fileRecord)
+                            .map(true)
+                            .recover(err -> this.getByUniqueId(fileRecord.uniqueId())
+                                    .compose(existing -> {
+                                        if (existing != null) {
+                                            log.debug("File record already exists (create race): %s".formatted(fileRecord.uniqueId()));
+                                            return Future.succeededFuture(false);
+                                        }
+                                        log.error(err, "Failed to create file record: %s".formatted(fileRecord.uniqueId()));
+                                        return Future.failedFuture(err);
+                                    })
+                            );
                 });
     }
 


### PR DESCRIPTION
## Problem

`createIfNotExist()` does a non-atomic check-then-insert: `getByUniqueId()` then `create()`. When the same file is started concurrently (e.g. auto-download picking it up while another path also starts it), both callers see "not found" and race to `INSERT`. The loser hits the composite primary key constraint, which is logged as SEVERE and **fails the whole download**:

```
[SEVERE] Failed to create file record: [SQLITE_CONSTRAINT_PRIMARYKEY] A PRIMARY KEY constraint failed (UNIQUE constraint failed: file_record.id, file_record.unique_id)
[SEVERE] Download file failed! ChatId: ... MessageId:... FileId:...
```

## Fix

- `createIfNotExist()` recovers from a lost create race (treats it as already-existing and returns `false`), so the caller proceeds instead of failing the download.
- The constraint/duplicate failure in `create()` is logged at `debug` (it's an expected race), while genuine create failures still log at `error`.

The duplicate detection is message-based (`constraint` / `duplicate`) so it stays portable across sqlite / postgres / mysql.