### PR TITLE
🐛 fix: keep the status-filtered file list consistent with live updates

### DIFF
--- a/web/src/components/file-status-filter.tsx
+++ b/web/src/components/file-status-filter.tsx
@@ -81,14 +81,14 @@ export default function FileStatusFilter({
       <div className="flex items-center space-x-2">
         {downloadStatus && (
           <div className="flex items-center space-x-1 rounded bg-gray-100 p-1 dark:bg-gray-800">
-            <span className="text-xs">Download</span>
             <downloadStatus.icon className="h-3 w-3" />
+            <span className="text-xs">{downloadStatus.text}</span>
           </div>
         )}
         {transferStatus && (
           <div className="flex items-center space-x-1 rounded bg-gray-100 p-1 dark:bg-gray-800">
-            <span className="text-xs">Transfer</span>
             <transferStatus.icon className="h-3 w-3" />
+            <span className="text-xs">{transferStatus.text}</span>
           </div>
         )}
       </div>

--- a/web/src/hooks/use-files.ts
+++ b/web/src/hooks/use-files.ts
@@ -189,7 +189,7 @@ export function useFiles(
         if (file.originalDeleted && latestFilesStatus[file.uniqueId]?.removed) {
           return;
         }
-        files.push({
+        const merged = {
           ...file,
           id: latestFilesStatus[file.uniqueId]?.fileId ?? file.id,
           downloadStatus:
@@ -209,7 +209,23 @@ export function useFiles(
           thumbnailFile:
             latestFilesStatus[file.uniqueId]?.thumbnailFile ??
             file.thumbnailFile,
-        });
+        };
+        // Live WebSocket updates can change a row's status after it was fetched. When a status
+        // filter is active, drop rows that no longer match so the filtered view stays consistent
+        // (otherwise e.g. a "downloading" filter keeps showing files that just completed).
+        if (
+          filters.downloadStatus &&
+          merged.downloadStatus !== filters.downloadStatus
+        ) {
+          return;
+        }
+        if (
+          filters.transferStatus &&
+          merged.transferStatus !== filters.transferStatus
+        ) {
+          return;
+        }
+        files.push(merged);
       });
     });
     files.forEach((file, index) => {
@@ -217,7 +233,12 @@ export function useFiles(
       file.next = files[index + 1];
     });
     return files;
-  }, [pages, latestFilesStatus]);
+  }, [
+    pages,
+    latestFilesStatus,
+    filters.downloadStatus,
+    filters.transferStatus,
+  ]);
 
   const hasMore = useMemo(() => {
     if (!pages || pages.length === 0) return true;


### PR DESCRIPTION
## Problem

Two small issues with the file status filter:

1. **Filtered list goes inconsistent with live updates.** The file list merges server data with live WebSocket status updates, but the merged list is never re-filtered. So with a `downloading` filter active, a file that has since completed (via a live update) keeps showing in the list with a `completed` status — it looks like the filter is broken / "changes statuses".
2. **The filter chip always reads "Download" / "Transfer"** with a tiny icon, regardless of which status is selected, instead of showing the selected status name.

## Fix

1. After merging live updates, re-apply the active `downloadStatus` / `transferStatus` filter client-side so rows that no longer match drop out (and add the filters to the memo deps).
2. Show the selected status label (Idle, Downloading, Error, …) in the chip instead of the hardcoded category name.

Frontend-only, no API changes.