### PR TITLE
fix: automation dialog loses in-progress rule edits on SWR revalidation

### DIFF
--- a/web/src/components/automation-dialog.tsx
+++ b/web/src/components/automation-dialog.tsx
@@ -138,6 +138,13 @@ export default function AutomationDialog() {
           setOpen(false);
         }, 1000);
       },
+      onError: (error: Error) => {
+        toast({
+          variant: "error",
+          title: "Failed to update auto settings",
+          description: error.message,
+        });
+      },
     },
   );
 
@@ -146,12 +153,18 @@ export default function AutomationDialog() {
   });
 
   useEffect(() => {
+    // Don't clobber in-progress edits: SWR revalidation (e.g. on window
+    // refocus) replaces `chat` while the form is open, which used to reset
+    // the local draft and cause silently-lost rule edits on save.
+    if (editMode) {
+      return;
+    }
     if (chat?.auto) {
       setAuto(chat.auto);
     } else {
       setAuto(DEFAULT_AUTO);
     }
-  }, [chat]);
+  }, [chat, editMode]);
 
   if (isLoading) {
     return <Skeleton className="h-8 w-32" />;


### PR DESCRIPTION
## Problem

When editing auto-download settings, the dialog syncs its local draft from `chat.auto` in an effect keyed on `[chat]`:

```tsx
useEffect(() => {
  if (chat?.auto) setAuto(chat.auto);
  else setAuto(DEFAULT_AUTO);
}, [chat]);
```

SWR revalidates the chats list on window refocus (default `revalidateOnFocus`). Any refocus while the form is open — e.g. the user switches windows to copy a filter expression and comes back — replaces the `chat` object, the effect fires, and the in-progress draft is silently reset to server state. Pressing **Update** then saves the reset rule, so keyword / file types / filter expression edits are lost with a success toast.

Reproduced on 0.4.0: configured query keyword + Video file type twice via the UI; both times the persisted `automation` setting ended up with an empty rule (`{"query":"","fileTypes":[],"filterExpr":""}`) while auto download stayed enabled — which also means the chat quietly falls back to downloading everything.

## Fix

- Skip the sync effect while `editMode` is active, so revalidation can no longer clobber a draft being edited (effect deps extended to `[chat, editMode]`, so leaving edit mode re-syncs from server state as before).
- Add an `onError` toast to the save mutation — previously only `onSuccess` was handled, so a failed save gave no feedback at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kkci3VFdZ4xc1Nysa2GhVS